### PR TITLE
faker の導入に関して修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     erubi (1.12.0)
+    faker (3.2.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
@@ -214,6 +216,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  faker
   importmap-rails
   jbuilder
   pg (~> 1.1)


### PR DESCRIPTION
## 概要
faker導入の際に追記されるGemfile.lockの変更がプッシュされていなかったため、追記

## 変更点
- Gemfile.lockにfakerを追記（手動ではなく、bundle installで自動的に書かれたもの）
